### PR TITLE
ApiError deserialization issue

### DIFF
--- a/Sdl.Community.GroupShareKit/Models/Response/ApiError.cs
+++ b/Sdl.Community.GroupShareKit/Models/Response/ApiError.cs
@@ -24,16 +24,16 @@ namespace Sdl.Community.GroupShareKit.Models.Response
         /// <summary>
         /// The error message
         /// </summary>
-        public string Message { get; protected set; }
+        public string Message { get; set; }
 
         /// <summary>
         /// URL to the documentation for this error.
         /// </summary>
-        public string DocumentationUrl { get; protected set; }
+        public string DocumentationUrl { get; set; }
 
         /// <summary>
         /// Additional details about the error
         /// </summary>
-        public IReadOnlyList<ApiErrorDetail> Errors { get; protected set; }
+        public IReadOnlyList<ApiErrorDetail> Errors { get; set; }
     }
 }


### PR DESCRIPTION
The ApiError doesn't seems to parse the message body correctly, due to private setters in the ApiError class. It causes the expection messages coming from the API not including the detail information from the REST API concerning the error type. In theory is should work with private setter, but it doesn't...