### PR TITLE
Fixing 'Characters' mapping bug.

### DIFF
--- a/Sdl.Community.GroupShareKit/Models/Response/AnalyseDetails.cs
+++ b/Sdl.Community.GroupShareKit/Models/Response/AnalyseDetails.cs
@@ -4,7 +4,7 @@
     {
         public string Segments { get; set; }
         public string Words { get; set; }
-        public string Chars { get; set; }
+        public string Characters { get; set; }
         public string Placeables { get; set; }
         public string Tags { get; set; }
     }


### PR DESCRIPTION
I found a bug with wrong parameter name mapping in Analysis Reports. Here is a small fix.